### PR TITLE
fix(connect) handle back to back connections

### DIFF
--- a/src/client/__tests__/socket.test.ts
+++ b/src/client/__tests__/socket.test.ts
@@ -41,6 +41,17 @@ describe("socket", () => {
     expect(socket.isConnected).toBeTruthy()
   })
 
+  it("handle 2 connections", async () => {
+    const mockFactory = jest.fn().mockImplementation(factory)
+
+    const socket = createEoswsSocket(mockFactory)
+
+    expect.hasAssertions()
+    socket.connect(noopListener)
+    socket.connect(noopListener)
+    expect(mockFactory).toHaveBeenCalledTimes(1)
+  })
+
   it("handles connection error properly", async () => {
     const socket = createEoswsSocket(factory)
     setTimeout(() => rejectConnection({ reason: "test" }), 0)

--- a/src/client/socket.ts
+++ b/src/client/socket.ts
@@ -74,6 +74,10 @@ class DefaultEoswsSocket implements EoswsSocket {
   public async connect(listener: SocketMessageListener): Promise<void> {
     this.debug("About to connect to remote endpoint.")
 
+    if (this.connectionPromise !== undefined) {
+      return this.connectionPromise
+    }
+
     this.listener = listener
     this.connectionPromise = new Promise<void>((resolve, reject) => {
       this.debug("Connection promise started, creating and opening socket.")


### PR DESCRIPTION
We need to be able to handle back to back connections as they can happen anywhere inside an application.