### PR TITLE
Updated library to support new version of `get_action_traces`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## In progress
 
-- TBA
+- Updated multi contracts example to use the new `accounts` parameter.
+- Updated library to support new version of `get_action_traces` (added `accounts`, `receivers` and `action_names`).
+
+### Deprecations
+
+Those are deprecation notices, they are still available in the current pre-release major version
+(`0.11.x` in this case). You are welcome to upgrade right now however.
+
+- Renamed `GetActionTracesMessageData#account` to `GetActionTracesMessageData#accounts`.
+- Renamed `GetActionTracesMessageData#receiver` to `GetActionTracesMessageData#receivers`.
+- Renamed `GetActionTracesMessageData#action_name` to `GetActionTracesMessageData#action_names`.
 
 ## 0.11.4 (November 22, 2018)
 

--- a/examples/get-action-traces-multi-contracts.ts
+++ b/examples/get-action-traces-multi-contracts.ts
@@ -13,18 +13,18 @@ const CONTRACTS = ["eosmechanics", "eosknightsio", "eosiotokener"]
 
 const onMessage = (message: InboundMessage<any>) => {
   switch (message.type) {
+    case InboundMessageType.LISTENING:
+      const listeningMessage = message as InboundMessage<ListeningData>
+      console.log(
+        `Received Listening message event (reqID: ${listeningMessage.req_id}, next_block: ${
+          listeningMessage.data.next_block
+        })`
+      )
+      break
+
     case InboundMessageType.ACTION_TRACE:
       const action = (message.data as ActionTraceData<any>).trace.act
       console.log(`Action "${action.name}" received for account "${action.account}".`)
-      break
-
-    case InboundMessageType.LISTENING:
-      const listeningResp = message as InboundMessage<ListeningData>
-      console.log(
-        `Received Listening message event, reqID: ${listeningResp.req_id}, next_block: ${
-          listeningResp.data.next_block
-        }`
-      )
       break
 
     case InboundMessageType.ERROR:
@@ -41,9 +41,7 @@ async function main() {
   const client = new EoswsClient(createEoswsSocket(socketFactory))
   await client.connect()
 
-  for (const account of CONTRACTS) {
-    client.getActionTraces({ account }).onMessage(onMessage)
-  }
+  client.getActionTraces({ accounts: CONTRACTS.join("|") }).onMessage(onMessage)
 
   console.log("Listening for messages for 20 seconds.")
   await waitFor(20000)

--- a/src/message/outbound.ts
+++ b/src/message/outbound.ts
@@ -25,9 +25,12 @@ export interface StreamOptions {
 }
 
 export interface GetActionTracesMessageData {
-  account: string
-  receiver?: string
-  action_name?: string
+  account?: string // @deprecated, will be removed in next major bump
+  accounts?: string
+  receiver?: string // @deprecated, will be removed in next major bump
+  receivers?: string
+  action_name?: string // @deprecated, will be removed in next major bump
+  action_names?: string
   with_dbops?: boolean
   with_dtrxops?: boolean
   with_ramops?: boolean


### PR DESCRIPTION
Updated multi contracts example to use the new `accounts` parameter.
Updated library to support new version of `get_action_traces` (added `accounts`, `receivers` and `action_names`).